### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 project = 'Kpop'
 project_title = project.title()
 author = 'F\\xe1bio Mac\\xeado Mendes'
-copyright = '2016, %s' % author
+copyright = '2016, {0!s}'.format(author)
 
 
 # The version info for the project you're documenting, acts as replacement for
@@ -206,7 +206,7 @@ html_static_path = ['_static']
 #html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = '%sdoc' % project
+htmlhelp_basename = '{0!s}doc'.format(project)
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -228,7 +228,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, '%s.tex' % project, '%s Documentation' % project,
+    (master_doc, '{0!s}.tex'.format(project), '{0!s} Documentation'.format(project),
      author, 'manual'),
 ]
 
@@ -258,7 +258,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, project, '%s Documentation' % project,
+    (master_doc, project, '{0!s} Documentation'.format(project),
      [author], 1)
 ]
 
@@ -272,7 +272,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, project, '%s Documentation' % project,
+    (master_doc, project, '{0!s} Documentation'.format(project),
      author, project, 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ version = open('VERSION').read().strip()
 dirname = os.path.dirname(__file__)
 path = os.path.join(dirname, 'src', 'kpop', '__meta__.py')
 meta = '''# Automatically created. Please do not edit.
-__version__ = '%s'
+__version__ = '{0!s}'
 __author__ = 'F\\xe1bio Mac\\xeado Mendes'
-''' % version
+'''.format(version)
 with open(path, 'w') as F:
     F.write(meta)
 

--- a/src/kpop/admixture/admixture.py
+++ b/src/kpop/admixture/admixture.py
@@ -72,7 +72,7 @@ def admixture(x, f_pops, method='bayes'):
         else:
             return np.array([p, 1 - p])
     else:
-        raise ValueError('invalid method, %s' % method)
+        raise ValueError('invalid method, {0!s}'.format(method))
 
 
 def admixture_maxlike(x, f_pops, optimizer='slsqrp', q0=None):
@@ -175,7 +175,7 @@ def admixture_maxlike(x, f_pops, optimizer='slsqrp', q0=None):
     elif optimizer == 'slsqrp_f':
         return fmin(func, q0, eqcons=[eqcons], bounds=bounds, disp=1)
     else:
-        raise ValueError('unknown method: %s' % optimizer)
+        raise ValueError('unknown method: {0!s}'.format(optimizer))
 
 
 def admixture_maxlike_1D(x, f_pops, method='bound'):
@@ -233,7 +233,7 @@ def admixture_maxlike_1D(x, f_pops, method='bound'):
         q = 0.5 + arctan(u) / pi
 
     else:
-        raise ValueError('invalid method: %s' % method)
+        raise ValueError('invalid method: {0!s}'.format(method))
 
     return np.array([q, 1 - q])
 

--- a/src/kpop/cli/create.py
+++ b/src/kpop/cli/create.py
@@ -24,7 +24,7 @@ def create(file, size=100, num_loci=100, clusters=1,
     pops = []
     for i in range(clusters):
         symbol = SYMBOL_TABLE[i]
-        label_x = label if clusters == 1 else '%s-%s' % (label, symbol)
+        label_x = label if clusters == 1 else '{0!s}-{1!s}'.format(label, symbol)
         pop = Population.make_random(size, num_loci, label=label_x)
         pops.append(pop)
 

--- a/src/kpop/cli/export.py
+++ b/src/kpop/cli/export.py
@@ -26,7 +26,7 @@ def export(pop, format=None, output=None, verbose=False):
     elif format == 'arlequin':
         return export_arlequin(pop, output)
     else:
-        raise ValueError('invalid format: %r' % format)
+        raise ValueError('invalid format: {0!r}'.format(format))
 
 
 def export_structure(pop, output, verbose):
@@ -41,7 +41,7 @@ def export_structure(pop, output, verbose):
     if not os.path.exists(folder):
         os.mkdir(folder)
     if not os.path.isdir(folder):
-        raise SystemExit('%s%s is not a folder' % (folder, os.sep))
+        raise SystemExit('{0!s}{1!s} is not a folder'.format(folder, os.sep))
 
     # Save params files
     printif(verbose, 'Creating param files')

--- a/src/kpop/cli/shell.py
+++ b/src/kpop/cli/shell.py
@@ -119,7 +119,7 @@ def get_first_cell_source_for_notebook(path):
         ext = load_best_ext(exts)
         name = python_name(file)
         file = os.path.join(path, file + ext)
-        lines.append('%s = load(%r)' % (name, file))
+        lines.append('{0!s} = load({1!r})'.format(name, file))
 
     return '\n'.join(lines)
 
@@ -141,7 +141,7 @@ def start_shell_namespace(path, verbose=False):
         ext = load_best_ext(exts)
         name = python_name(file)
         file = os.path.join(path, file + ext)
-        printif(verbose, '    - %s from %r' % (name, file))
+        printif(verbose, '    - {0!s} from {1!r}'.format(name, file))
         result[name] = load(file)
     printif(verbose, '')
 
@@ -197,4 +197,4 @@ def python_name(name):
         if NAME_RE.match(name):
             return name
     else:
-        raise ValueError('canot convert to valid python name: %r' % old_name)
+        raise ValueError('canot convert to valid python name: {0!r}'.format(old_name))

--- a/src/kpop/cli/show.py
+++ b/src/kpop/cli/show.py
@@ -15,4 +15,4 @@ def show(pop, method, verbose=False):
     if method == 'pca':
         pop.plot.pca()
     else:
-        raise SystemExit('invalid method: %r' % method)
+        raise SystemExit('invalid method: {0!r}'.format(method))

--- a/src/kpop/cli/stats.py
+++ b/src/kpop/cli/stats.py
@@ -13,8 +13,8 @@ def stats(pop, verbose=False, json=False):
     """
 
     click.echo('summary:')
-    click.echo('    size: %s' % pop.size)
-    click.echo('    num_loci: %s' % pop.num_loci)
-    click.echo('    ploidy: %s' % pop.ploidy)
-    click.echo('    num_alleles: %s' % pop.num_alleles)
-    click.echo('    missing_ratio: %.3e' % pop.missing_ratio)
+    click.echo('    size: {0!s}'.format(pop.size))
+    click.echo('    num_loci: {0!s}'.format(pop.num_loci))
+    click.echo('    ploidy: {0!s}'.format(pop.ploidy))
+    click.echo('    num_alleles: {0!s}'.format(pop.num_alleles))
+    click.echo('    missing_ratio: {0:.3e}'.format(pop.missing_ratio))

--- a/src/kpop/external/admixture/base.py
+++ b/src/kpop/external/admixture/base.py
@@ -51,7 +51,7 @@ def run_admixture(pop, k, job_dir=None, disp=1, supervised=False):
                 if label is None:
                     F.write('-\n')
                 else:
-                    F.write('%s\n' % label)
+                    F.write('{0!s}\n'.format(label))
 
     # Convert everything to a binary format since it seems that ADMIXTURE does
     # not support the regular .ped files (?)
@@ -59,7 +59,7 @@ def run_admixture(pop, k, job_dir=None, disp=1, supervised=False):
     try:
         subprocess.run(cmd, stdout=PIPE, check=True, cwd=job_dir)
     except subprocess.CalledProcessError as ex:
-        msg = 'plink ended with runtime code %s.\n\n' % ex.returncode
+        msg = 'plink ended with runtime code {0!s}.\n\n'.format(ex.returncode)
         msg += ex.stdout.decode('utf8')
         raise RuntimeError(msg)
 
@@ -73,20 +73,20 @@ def run_admixture(pop, k, job_dir=None, disp=1, supervised=False):
     try:
         result = subprocess.run(cmd, stdout=PIPE, check=True, cwd=job_dir)
     except subprocess.CalledProcessError as ex:
-        msg = 'ADMIXTURE ended with runtime code %s.\n\n' % ex.returncode
+        msg = 'ADMIXTURE ended with runtime code {0!s}.\n\n'.format(ex.returncode)
         msg += ex.stdout.decode('utf8')
         raise RuntimeError(msg)
     admix_out = result.stdout.decode('utf8')
 
     # Read the output .P file with allele frequencies
-    with open(os.path.join(job_dir, 'job.%s.P' % k)) as F:
+    with open(os.path.join(job_dir, 'job.{0!s}.P'.format(k))) as F:
         data = []
         for line in F:
             data.append(list(map(float, line.strip().split())))
     freqs = np.array(data).T
 
     # Read the output .Q file with admixture coefficients
-    with open(os.path.join(job_dir, 'job.%s.Q' % k)) as F:
+    with open(os.path.join(job_dir, 'job.{0!s}.Q'.format(k))) as F:
         data = []
         for line in F:
             data.append(list(map(float, line.strip().split())))

--- a/src/kpop/external/admixture/result.py
+++ b/src/kpop/external/admixture/result.py
@@ -51,7 +51,7 @@ class AdmixtureResult:
                                    num_loci=self.num_loci)
         for i, freqs in enumerate(self.freqs_vector_pop):
             if labels is None:
-                label = 'pop-%s' % (i + 1)
+                label = 'pop-{0!s}'.format((i + 1))
             else:
                 label = labels[i]
             pop = Population(freqs=freqs, ploidy=self.ploidy, label=label)

--- a/src/kpop/external/structure/base.py
+++ b/src/kpop/external/structure/base.py
@@ -58,10 +58,10 @@ def run_structure(pop, k=2, *, method='parental', job_dir=None,
 
     # Display input files
     if disp >= 1:
-        print('Started structure analysis at %r' % job_dir)
+        print('Started structure analysis at {0!r}'.format(job_dir))
         for file in os.listdir(job_dir):
             size = os.path.getsize(os.path.join(job_dir, file))
-            print('    %s (%.2f kb)' % (file, size/1024))
+            print('    {0!s} ({1:.2f} kb)'.format(file, size/1024))
     if disp >= 2:
         print()
         print('MAINPARAMS\n' + '-' * 80, '\n' + main, '\n\n')
@@ -78,7 +78,7 @@ def run_structure(pop, k=2, *, method='parental', job_dir=None,
     # Execute
     error = subprocess.check_call(cmd, shell=True, cwd=job_dir)
     if error != 0:
-        raise RuntimeError('structure returned with error code: %s' % error)
+        raise RuntimeError('structure returned with error code: {0!s}'.format(error))
 
     # Read output file
     # (I don't know why Structure prepends an "_f" to the end of file)
@@ -256,5 +256,5 @@ def params_file(data):
 
     lst = []
     for k, v in sorted(data.items()):
-        lst.append('#define %s %s' % (k.upper(), normalize(v)))
+        lst.append('#define {0!s} {1!s}'.format(k.upper(), normalize(v)))
     return '\n'.join(sorted(lst))

--- a/src/kpop/external/structure/result.py
+++ b/src/kpop/external/structure/result.py
@@ -182,7 +182,7 @@ class StructureResult:
             missing_allele_freqs.append(missing_fraction)
             if n_alleles != len(lines):
                 raise ValueError(
-                    'unexpected number of alleles: %s' % n_alleles)
+                    'unexpected number of alleles: {0!s}'.format(n_alleles))
 
             parental_freqs = Counter()
             total_allele_freqs.append(parental_freqs)

--- a/src/kpop/individual.py
+++ b/src/kpop/individual.py
@@ -161,7 +161,7 @@ class Individual(collections.Sequence):
         return iter(self._data)
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self.render(limit=20))
+        return '{0!s}({1!r})'.format(self.__class__.__name__, self.render(limit=20))
 
     def __str__(self):
         return self.render()
@@ -247,7 +247,7 @@ class Individual(collections.Sequence):
         """
 
         data = '  '.join(' '.join(map(str, locus)) for locus in self.data)
-        return '%s  %s  %s %s  %s  %s  %s' % (
+        return '{0!s}  {1!s}  {2!s} {3!s}  {4!s}  {5!s}  {6!s}'.format(
             family_id, individual_id, paternal_id, maternal_id, sex, phenotype,
             data
         )
@@ -331,7 +331,7 @@ def label_from_parents(l1, l2):
     common = ''.join(common)
     l1 = l1[len(common):] or '_'
     l2 = l2[len(common):] or '_'
-    return '%s-%s,%s' % (common, l1, l2)
+    return '{0!s}-{1!s},{2!s}'.format(common, l1, l2)
 
 
 def random_data_from_freqs_matrix(freqs, ploidy=2):

--- a/src/kpop/loaders.py
+++ b/src/kpop/loaders.py
@@ -132,4 +132,4 @@ def load(file):
     elif name.endswith('.pickle'):
         return load_pickle(file)
     else:
-        raise ValueError('could not determine file type for %r' % file)
+        raise ValueError('could not determine file type for {0!r}'.format(file))

--- a/src/kpop/loci_data.py
+++ b/src/kpop/loci_data.py
@@ -58,18 +58,18 @@ class Locus:
         self.allele_names[value] = name
 
     def __repr__(self):
-        return '%s(%r, num_alleles=%r)' % (self.name, self.num_alleles)
+        return '{0!s}({1!r}, num_alleles={2!r})'.format(self.name, self.num_alleles)
 
     def render_map(self):
         """
         Render locus data as a line in a .MAP file.
         """
 
-        return '%s %s %s %s' % (
+        return '{0!s} {1!s} {2!s} {3!s}'.format(
             self.chromosome or 0,
             self.name,
             self.position or 0,
-            self.genetic_distance or -1,
+            self.genetic_distance or -1
         )
 
 
@@ -82,7 +82,7 @@ class LociSequence(collections.Sequence):
                  positions=None, genetic_distances=None):
 
         if isinstance(names, int):
-            names = ['marker%s' % i for i in range(names)]
+            names = ['marker{0!s}'.format(i) for i in range(names)]
 
         self._data = data = []
         self._names_map = names_map = {}
@@ -99,7 +99,7 @@ class LociSequence(collections.Sequence):
                           genetic_distance=genetic_distances[i])
             data.append(locus)
             if name in names_map:
-                raise ValueError('repeated marker name: %r' % name)
+                raise ValueError('repeated marker name: {0!r}'.format(name))
             names_map[name] = i
 
     def __getitem__(self, index):

--- a/src/kpop/plots.py
+++ b/src/kpop/plots.py
@@ -14,7 +14,7 @@ def unique_colors(n, colormap=cm.rainbow):
         try:
             colormap = getattr(cm, colormap)
         except AttributeError:
-            raise ValueError('invalid colormap: %r' % colormap)
+            raise ValueError('invalid colormap: {0!r}'.format(colormap))
     size = colormap.N
     yield colormap(0)
     if n > 1:
@@ -49,7 +49,7 @@ def _pop_sizes(pop_sizes, total):
         pop_sizes = np.array(pop_sizes, dtype=int)
         if sum(pop_sizes) != total:
             fmt = total, sum(pop_sizes)
-            raise ValueError('pop_sizes assumes %s individuals, got %s' % fmt)
+            raise ValueError('pop_sizes assumes {0!s} individuals, got {1!s}'.format(*fmt))
     return pop_sizes
 
 
@@ -57,8 +57,7 @@ def _pop_labels(pop_labels, n, fmt='pop-%s'):
     if pop_labels is None:
         pop_labels = [fmt % n for n in range(1, n + 1)]
     elif len(pop_labels) != n:
-        raise ValueError('expect %s populations, got %r' %
-                         (n, list(pop_labels)))
+        raise ValueError('expect {0!s} populations, got {1!r}'.format(n, list(pop_labels)))
     return pop_labels
 
 
@@ -74,8 +73,7 @@ def group_individuals(data, chunk_sizes=None):
         chunk_sizes = [len(data)]
 
     if sum(chunk_sizes) != len(data):
-        raise ValueError('expect %s individuals, got %s' %
-                         (sum(chunk_sizes), len(data)))
+        raise ValueError('expect {0!s} individuals, got {1!s}'.format(sum(chunk_sizes), len(data)))
 
     result = []
     data = iter(data)

--- a/src/kpop/population/attr_plots.py
+++ b/src/kpop/population/attr_plots.py
@@ -24,7 +24,7 @@ class PlotAttribute:
         populations = (population or self._population).populations
         labels = []
         for i, pop in enumerate(populations):
-            label = pop.label if pop.label else 'pop-%s' % i
+            label = pop.label if pop.label else 'pop-{0!s}'.format(i)
             labels.append(label)
         return labels
 
@@ -63,7 +63,7 @@ class PlotAttribute:
         pop_sizes = [pop.num_loci for pop in populations]
         pop_labels = [pop.label or i for i, pop in enumerate(populations)]
         alleles = data.shape[1]
-        labels = ['allele-%s' % (i + 1) for i in range(alleles)]
+        labels = ['allele-{0!s}'.format((i + 1)) for i in range(alleles)]
         if sorted:
             data *= -1
             data.sort(axis=-1)

--- a/src/kpop/population/attr_populations.py
+++ b/src/kpop/population/attr_populations.py
@@ -55,7 +55,7 @@ class PopulationsList(collections.MutableSequence):
                 if idx == pop.label:
                     return i
             else:
-                raise KeyError('invalid label: %r' % idx)
+                raise KeyError('invalid label: {0!r}'.format(idx))
 
     def labels(self, prefix='pop'):
         """

--- a/src/kpop/population/mixin_population_render.py
+++ b/src/kpop/population/mixin_population_render.py
@@ -52,10 +52,10 @@ class RenderablePopulationMixin(abc.ABC):
 
         names = self.allele_names
         if names is None:
-            names = ['loci%s' % i for i in range(1, self.size + 1)]
+            names = ['loci{0!s}'.format(i) for i in range(1, self.size + 1)]
         header = 'label,' + ','.join(names)
         data = '\n'.join(x.render_csv(**kwargs) for x in self)
-        return '%s\n%s' % (header, data)
+        return '{0!s}\n{1!s}'.format(header, data)
 
     def render_ped(self):
         """
@@ -76,7 +76,7 @@ class RenderablePopulationMixin(abc.ABC):
 
         data = []
         for j in range(1, self.num_loci + 1):
-            data.append('1 snp%s 0 %s' % (j, j))
+            data.append('1 snp{0!s} 0 {1!s}'.format(j, j))
         return '\n'.join(data)
 
     def save(self, file, format='pickle', **kwargs):
@@ -99,4 +99,4 @@ class RenderablePopulationMixin(abc.ABC):
             with open(file, 'w') as F:
                 F.write(data)
         else:
-            raise ValueError('invalid file format: %r' % format)
+            raise ValueError('invalid file format: {0!r}'.format(format))

--- a/src/kpop/population/population_base.py
+++ b/src/kpop/population/population_base.py
@@ -317,7 +317,7 @@ class PopulationBase(RenderablePopulationMixin, collections.Sequence):
         children = []
         for i in range(size):
             father, mother = self.random_individual(), population.random_individual()
-            child = father.breed(mother, label='%s%s' % (label, i), **kwargs)
+            child = father.breed(mother, label='{0!s}{1!s}'.format(label, i), **kwargs)
             children.append(child)
         return kpop.Population(children, parent=parent, label=label)
 
@@ -556,7 +556,7 @@ class PopulationBase(RenderablePopulationMixin, collections.Sequence):
 
     def _next_label(self):
         self._last_label_index += 1
-        return '%s%s' % (self.label or 'ind', self._last_label_index)
+        return '{0!s}{1!s}'.format(self.label or 'ind', self._last_label_index)
 
 
 def _sub_population_label(label, n_gen):
@@ -565,4 +565,4 @@ def _sub_population_label(label, n_gen):
     if label is None:
         return None
     else:
-        return '%s-gen%s' % (label, n_gen)
+        return '{0!s}-gen{1!s}'.format(label, n_gen)

--- a/src/kpop/prob.py
+++ b/src/kpop/prob.py
@@ -63,7 +63,7 @@ class Prob(collections.Mapping):
         return iter(self._data)
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self._data)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, self._data)
 
     def __eq__(self, other):
         if isinstance(other, collections.Mapping):
@@ -104,7 +104,7 @@ class Prob(collections.Mapping):
         support = set(support)
         for x in self:
             if x not in support:
-                raise ValueError('%r not in support' % x)
+                raise ValueError('{0!r} not in support'.format(x))
         self.update_support(support)
 
     def entropy(self):

--- a/src/kpop/tests/test_documentation.py
+++ b/src/kpop/tests/test_documentation.py
@@ -37,7 +37,7 @@ def make_manuel_suite(ns):
     # Copy tests from the suite to the global namespace
     suite = manuel.testing.TestSuite(m, *files)
     for i, test in enumerate(suite):
-        name = 'test_doc_%s' % i
+        name = 'test_doc_{0!s}'.format(i)
         ns[name] = pytest.mark.documentation(_wrapped(test.runTest, name))
     return suite
 

--- a/tasks.py
+++ b/tasks.py
@@ -9,4 +9,4 @@ def configure(ctx):
     Instructions for preparing package for development.
     """
 
-    run("%s -m pip install .[dev] -r requirements.txt" % sys.executable)
+    run("{0!s} -m pip install .[dev] -r requirements.txt".format(sys.executable))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:fabiommendes:kpop?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:fabiommendes:kpop?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)